### PR TITLE
Add a column 'contact id' to schema of guests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,4 +2,4 @@ require 'sinatra/activerecord'
 require 'sinatra/activerecord/rake'
 
 ActiveRecord::Base.configurations = YAML.load_file('database.yml')
-ActiveRecord::Base.establish_connection('development')
+ActiveRecord::Base.establish_connection(:development)

--- a/db/migrate/20141228015544_add_contact_id_guests.rb
+++ b/db/migrate/20141228015544_add_contact_id_guests.rb
@@ -1,0 +1,5 @@
+class AddContactIdGuests < ActiveRecord::Migration
+  def change
+  	add_column :guests, :contact_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141125031218) do
+ActiveRecord::Schema.define(version: 20141228015544) do
 
   create_table "guests", id: false, force: true do |t|
     t.string   "id",          null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20141125031218) do
     t.string   "url"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "contact_id"
   end
 
   add_index "guests", ["id"], name: "index_guests_on_id", unique: true


### PR DESCRIPTION
内容に問題なければ，しまむー or 村上くんがマージして下さい．

変更理由:
アドレス帳の”Row”とサーバーの"Guest"を関連付けるKeyとしてContact IDを追加しました．
iOSもAndroidもアドレス帳にはRowに対して一意なIDが付与されて，それを格納します．

この情報は，ユースケースとして「一度作成したパーティに新たに別の"Guests"を招待する時」
「一度端末からアプリを削除したあと，再度インストールしなおした際にパーティ情報を復元する時」などに必要です．

アドレス帳の”Row”とサーバーの"Guest"を関連付けるKeyとして他にも名前や電話番号が利用できるかと考えましたが，
アドレス帳の名前や電話番号は端末のユーザーが変更できること，電話番号は複数のユーザーで共有する可能性がある
ことを考え不向きだと結論付けました．
